### PR TITLE
Add first version of job monitor starter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Maven image to build the library
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+
+# Set workdir
+WORKDIR /app
+
+# Copy pom and source files
+COPY pom.xml .
+COPY src ./src
+
+# Download dependencies and build the jar
+RUN mvn clean install -DskipTests
+
+# Runtime image just to hold the jar (optional)
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /spring-boot-job-monitor
+
+# Copy the built jar from the build stage
+COPY --from=build /app/target/*.jar ./spring-boot-job-monitor.jar
+
+# Optional entrypoint for test or debugging (most libraries don’t need this)
+CMD ["java", "-jar", "spring-boot-job-monitor.jar"]

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.3</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.medtech</groupId>
+    <artifactId>spring-boot-job-monitor</artifactId>
+    <version>0.0.2</version>
+    <name>spring-boot-job-monitor</name>
+    <description>spring-boot-job-monitor</description>
+    <packaging>jar</packaging>
+    <url/>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>berrachdi</id>
+            <name>Mohamed Berrachdi</name>
+            <email>berrachdim@gmail.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/berrachdi/spring-boot-job-monitor</url>
+        <connection>scm:git:git://github.com/berrachdi/spring-boot-job-monitor.git</connection>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/src/main/java/org/medtech/springbootjobmonitor/SpringBootJobMonitorApplication.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/SpringBootJobMonitorApplication.java
@@ -1,0 +1,13 @@
+package org.medtech.springbootjobmonitor;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableAspectJAutoProxy
+@EnableScheduling
+public class SpringBootJobMonitorApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringBootJobMonitorApplication.class, args);
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/annotation/JobName.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/annotation/JobName.java
@@ -1,0 +1,10 @@
+package org.medtech.springbootjobmonitor.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JobName {
+    String value();
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/aspect/JobMonitorAspect.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/aspect/JobMonitorAspect.java
@@ -1,0 +1,59 @@
+package org.medtech.springbootjobmonitor.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.medtech.springbootjobmonitor.annotation.JobName;
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+import org.medtech.springbootjobmonitor.service.JobMonitoringService;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * Aspect to monitor scheduled jobs and log their execution details.
+ * This aspect intercepts methods annotated with @Scheduled,
+ * records their execution time, success status, and any error messages,
+ * and stores this information in a JobExecutionLog.
+ */
+@Component
+@Aspect
+public class JobMonitorAspect {
+    private final JobMonitoringService jobMonitoringService;
+
+    public JobMonitorAspect(JobMonitoringService jobMonitoringService) {
+        this.jobMonitoringService = jobMonitoringService;
+    }
+
+    @Around("@annotation(scheduled)")
+    public Object monitorScheduledJob(ProceedingJoinPoint joinPoint, Scheduled scheduled) throws Throwable {
+        String jobName = joinPoint.getSignature().getName();
+
+        JobName customJobName = AnnotationUtils.findAnnotation(
+                joinPoint.getTarget().getClass().getMethod(joinPoint.getSignature().getName()), JobName.class);
+        if (customJobName != null) {
+            jobName = customJobName.value();
+        }
+
+        LocalDateTime start = LocalDateTime.now();
+        boolean success = true;
+        String errorMessage = null;
+
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable ex) {
+            success = false;
+            errorMessage = ex.getMessage();
+            throw ex;
+        } finally {
+            LocalDateTime end = LocalDateTime.now();
+            long duration = java.time.Duration.between(start, end).toMillis();
+
+            JobExecutionLog log = new JobExecutionLog(jobName, start, end, duration, success, errorMessage);
+
+            jobMonitoringService.addLog(jobName, log);
+    }
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/autoconfig/JobMonitorAutoConfiguration.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/autoconfig/JobMonitorAutoConfiguration.java
@@ -1,0 +1,40 @@
+package org.medtech.springbootjobmonitor.autoconfig;
+
+import org.medtech.springbootjobmonitor.storage.InMemoryJobLogStorage;
+import org.medtech.springbootjobmonitor.storage.JdbcJobLogStorage;
+import org.medtech.springbootjobmonitor.storage.JobLogStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+@ComponentScan("org.medtech.springbootjobmonitor")
+public class JobMonitorAutoConfiguration {
+
+    @Configuration
+    @ConditionalOnClass(name = "javax.sql.DataSource")
+    @ConditionalOnProperty(prefix = "spring.datasource", name = "url")
+    static class JdbcJobLogConfiguration {
+        @Bean
+        @ConditionalOnMissingBean(JobLogStorage.class)
+        public JobLogStorage jdbcJobLogStorage(DataSource dataSource) {
+            return new JdbcJobLogStorage(new JdbcTemplate(dataSource));
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JobLogStorage.class)
+    public JobLogStorage inMemoryJobLogStorage() {
+        return new InMemoryJobLogStorage();
+    }
+
+}
+

--- a/src/main/java/org/medtech/springbootjobmonitor/controller/JobMonitorController.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/controller/JobMonitorController.java
@@ -1,0 +1,31 @@
+package org.medtech.springbootjobmonitor.controller;
+
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+import org.medtech.springbootjobmonitor.service.JobMonitoringService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/job-monitor")
+public class JobMonitorController {
+    private final JobMonitoringService monitoringService;
+
+    public JobMonitorController(JobMonitoringService monitoringService) {
+        this.monitoringService = monitoringService;
+    }
+
+    @GetMapping
+    public Map<String, List<JobExecutionLog>> getAllLogs() {
+        return monitoringService.getAllLogs();
+    }
+
+    @GetMapping("/{jobName}")
+    public List<JobExecutionLog> getLogsForJob(@PathVariable String jobName) {
+        return monitoringService.getLogsForJob(jobName);
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/model/JobExecutionLog.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/model/JobExecutionLog.java
@@ -1,0 +1,21 @@
+package org.medtech.springbootjobmonitor.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * JobExecutionLog` is a record that represents the log of a job execution.
+ * @param jobName
+ * @param startTime
+ * @param endTime
+ * @param durationMs
+ * @param success
+ * @param errorMessage
+ */
+public record JobExecutionLog(
+        String jobName,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        long durationMs,
+        boolean success,
+        String errorMessage
+) {}

--- a/src/main/java/org/medtech/springbootjobmonitor/service/JobMonitoringService.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/service/JobMonitoringService.java
@@ -1,0 +1,33 @@
+package org.medtech.springbootjobmonitor.service;
+
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+import org.medtech.springbootjobmonitor.storage.JobLogStorage;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for monitoring job executions and storing logs.
+ * This service allows adding logs for specific jobs and retrieving logs for all jobs or a specific job.
+ */
+@Service
+public class JobMonitoringService {
+    private final JobLogStorage jobLogStorage;
+
+    public JobMonitoringService(JobLogStorage jobLogStorage) {
+        this.jobLogStorage = jobLogStorage;
+    }
+
+    public void addLog(String jobName, JobExecutionLog log) {
+        jobLogStorage.addLog(jobName, log);
+    }
+
+    public Map<String, List<JobExecutionLog>> getAllLogs() {
+        return jobLogStorage.getAllLogs();
+    }
+
+    public List<JobExecutionLog> getLogsForJob(String jobName) {
+        return jobLogStorage.getLogsForJob(jobName);
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/storage/InMemoryJobLogStorage.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/storage/InMemoryJobLogStorage.java
@@ -1,0 +1,31 @@
+package org.medtech.springbootjobmonitor.storage;
+
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of JobLogStorage.
+ * This class stores job execution logs in memory using a ConcurrentHashMap.
+ */
+public class InMemoryJobLogStorage implements JobLogStorage{
+    private final Map<String, List<JobExecutionLog>> logs = new ConcurrentHashMap<>();
+
+    @Override
+    public void addLog(String jobName, JobExecutionLog log) {
+        logs.computeIfAbsent(jobName, k -> new ArrayList<>()).add(log);
+    }
+    @Override
+    public List<JobExecutionLog> getLogsForJob(String jobName) {
+        return logs.getOrDefault(jobName, Collections.emptyList());
+    }
+
+    @Override
+    public Map<String, List<JobExecutionLog>> getAllLogs() {
+          return logs;
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/storage/JdbcJobLogStorage.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/storage/JdbcJobLogStorage.java
@@ -1,0 +1,91 @@
+package org.medtech.springbootjobmonitor.storage;
+
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of JobLogStorage that uses JDBC to store job execution logs.
+ */
+public class JdbcJobLogStorage implements JobLogStorage{
+    public static final String JOB_NAME = "job_name";
+    public static final String START_TIME = "start_time";
+    public static final String END_TIME = "end_time";
+    public static final String DURATION_MS = "duration_ms";
+    public static final String SUCCESS = "success";
+    public static final String ERROR_MESSAGE = "error_message";
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcJobLogStorage(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        ensureTableExists();
+    }
+
+    private void ensureTableExists() {
+        try {
+            jdbcTemplate.execute("SELECT 1 FROM job_logs LIMIT 1");
+        } catch (DataAccessException ex) {
+            jdbcTemplate.execute("""
+            CREATE TABLE job_logs (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                job_name VARCHAR(255),
+                start_time TIMESTAMP,
+                end_time TIMESTAMP,
+                duration_ms BIGINT,
+                success BOOLEAN,
+                error_message TEXT
+            )
+        """);
+        }
+    }
+
+    @Override
+    public void addLog(String jobName, JobExecutionLog log) {
+        jdbcTemplate.update(
+                "INSERT INTO job_logs (job_name, start_time, end_time, duration_ms, success, error_message) VALUES (?, ?, ?, ?, ?, ?)",
+                jobName,
+                log.startTime(),
+                log.endTime(),
+                log.durationMs(),
+                log.success(),
+                log.errorMessage()
+        );
+    }
+
+    @Override
+    public List<JobExecutionLog> getLogsForJob(String jobName) {
+        return jdbcTemplate.query(
+                "SELECT * FROM job_logs WHERE job_name = ? ORDER BY start_time DESC LIMIT 50",
+                (rs, rowNum) -> new JobExecutionLog(
+                        rs.getString(JOB_NAME),
+                        rs.getTimestamp(START_TIME).toLocalDateTime(),
+                        rs.getTimestamp(END_TIME).toLocalDateTime(),
+                        rs.getLong(DURATION_MS),
+                        rs.getBoolean(SUCCESS),
+                        rs.getString(ERROR_MESSAGE)
+                ),
+                jobName
+        );
+    }
+
+    @Override
+    public Map<String, List<JobExecutionLog>> getAllLogs() {
+        List<JobExecutionLog> allLogs = jdbcTemplate.query(
+                "SELECT * FROM job_logs ORDER BY start_time DESC " ,
+                (rs, rowNum) -> new JobExecutionLog(
+                        rs.getString(JOB_NAME),
+                        rs.getTimestamp(START_TIME).toLocalDateTime(),
+                        rs.getTimestamp(END_TIME).toLocalDateTime(),
+                        rs.getLong(DURATION_MS),
+                        rs.getBoolean(SUCCESS),
+                        rs.getString(ERROR_MESSAGE)
+                )
+        );
+        return allLogs.stream()
+                .collect(Collectors.groupingBy(JobExecutionLog::jobName));
+    }
+}

--- a/src/main/java/org/medtech/springbootjobmonitor/storage/JobLogStorage.java
+++ b/src/main/java/org/medtech/springbootjobmonitor/storage/JobLogStorage.java
@@ -1,0 +1,18 @@
+package org.medtech.springbootjobmonitor.storage;
+
+import org.medtech.springbootjobmonitor.model.JobExecutionLog;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for storing and retrieving job execution logs.
+ * This interface defines methods to add logs for a specific job,
+ * retrieve logs for a specific job, and get all job names
+ * that have logs stored.
+ */
+public interface JobLogStorage {
+    void addLog(String jobName, JobExecutionLog log);
+    List<JobExecutionLog> getLogsForJob(String jobName);
+    Map<String, List<JobExecutionLog>> getAllLogs();
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.medtech.springbootjobmonitor.autoconfig.JobMonitorAutoConfiguration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=spring-boot-job-monitor


### PR DESCRIPTION
This pull request introduces the initial version of the spring-boot-job-monitor library. The project provides essential features to track and expose job executions in Spring Boot applications, aiming to facilitate observability and operational monitoring.

✅ Features Included

- Spring Boot starter module structure
- Basic job execution tracking logic
- Integration with Spring’s TaskScheduler / @Scheduled annotations
- Job execution status storage (in-memory and database) support
- Health endpoint or actuator integration placeholder
- Basic error handling and logging

🛠️ Technologies

- Java 17
- Spring Boot 3.5.3
- Maven