### PR TITLE
Add unit tests for JobMonitoringService (#2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Berrachdi Mohamed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# spring-boot-job-monitor
+Spring Boot Job Monitor is a lightweight starter library that enables automatic monitoring of job executions in Spring Boot applications. It supports both in-memory and JDBC-based storage, exposes logs through REST endpoints, and can optionally integrate with Prometheus for observability — all with zero configuration from the client side.


### PR DESCRIPTION
This PR adds unit tests for the `JobMonitoringService` class as requested in [#2](
The tests ensure correct delegation to the `JobLogStorage` and validate the expected results for:

- Adding a job execution log
- Retrieving all job logs
- Retrieving logs for a specific job

---

## Covered Methods

- `addLog(String jobName, JobExecutionLog log)`
- `getAllLogs()`
- `getLogsForJob(String jobName)`

---

##  Details

- Used **Mockito** to mock `JobLogStorage`
- Verified interactions using `verify(...)`
- Used `LocalDateTime.of(...)` to ensure deterministic timestamps
- Added simple `System.out.println(...)` statements for test visibility

---

## 📈 Test Results

All tests passed successfully:
<img width="482" height="140" alt="image" src="https://github.com/user-attachments/assets/1c0dc6ea-851d-49a2-9a43-13a9e18bb2b7" />

## Notes
No changes were made to production code. Tests are isolated 